### PR TITLE
[WIP] Add support for Radxa RockPI 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Keeping this project running is very expensive, e.g. I have to buy a lot of diff
 
     :warning: WARNING: Do not connect RPI-RF-MOD to a power source. Do connect the NanoPC to a power source only.
   * NanoPi M4 running Armbian with Dev kernel (Experimental)
+  * Radxa Rock Pi 4 running with Armbian with Dev kernel (Experimental)
   * Rock64 running Armbian with Dev kernel (Experimental) (LEDs of RPI-RF-MOD not supported due to incompatible GPIO pin header)
   * RockPro64 running Armbian with Dev kernel (Experimental)
 

--- a/create_devicetree_armbian.sh
+++ b/create_devicetree_armbian.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-PKG_BUILD=24
+PKG_BUILD=25
 
 CURRENT_DIR=$(pwd)
 WORK_DIR=$(mktemp -d)

--- a/dts/armbian/detect_board.inc
+++ b/dts/armbian/detect_board.inc
@@ -72,6 +72,12 @@ if [ ! -z "$DEV_TREE_COMPATIBLE" ]; then
         INCLUDE_FILE='/var/lib/piVCCU/dts/nanopim4.dts.include'
         break
         ;;
+     radxa,rockpi4)
+        OVERLAY_MODE='patch'
+        INCLUDE_FILE='/var/lib/piVCCU/dts/rock-pi-4.dts.include'
+        FDT_FILE=rockchip/rk3399-rock-pi-4.dtb
+        break
+        ;;
     esac
   done
 fi

--- a/dts/rock-pi-4.dts.include
+++ b/dts/rock-pi-4.dts.include
@@ -1,0 +1,35 @@
+/ {
+  serial@ff1a0000 {
+    compatible = "pivccu,dw_apb";
+    pivccu,reset_pin = <&pivccu_gpio4 3 0>;
+    pivccu,red_pin = <&pivccu_gpio4 4 0>;
+    pivccu,green_pin = <&pivccu_gpio4 6 0>;
+    pivccu,blue_pin = <&pivccu_gpio4 7 0>;
+    pinctrl-0 = <&pivccu_uart2c_xfer>;
+  };
+
+  pinctrl {
+    pivccu_gpio4: gpio4@ff790000 {
+    };
+    uart2c {
+      pivccu_uart2c_xfer: uart2c-xfer {
+      };
+    };
+  };
+
+  i2c@ff160000 {
+    status = "okay";
+
+    rx8130@32 {
+      compatible = "epson,rx8130-legacy";
+      reg = <0x32>;
+      status = "okay";
+      enable-external-capacitor;
+    };
+  };
+
+  chosen {
+    stdout-path = "";
+    bootargs = "";
+  };
+};


### PR DESCRIPTION
I finally managed to get a board (
https://github.com/alexreinert/piVCCU/issues/119) and would like to add support for piVCCU.

Currently, besides testing it, the only (and probably most difficult piece) that is missing is the dts include file. I couldn't find documentation within the project on how to generate it.

If someone could assist me with that, that would be great. Board is running here and I can test things if necessary.

https://wiki.radxa.com/Rockpi4/hardware/gpio

comparing that with https://forum.frank-mankel.org/assets/uploads/files/1537460598918-rockpro64_gpio_reference.png it looks like it might be pretty similar to the rockpro64 one.