### PR TITLE
pivccu-backup mit Cron Jobs kompatibel machen

### DIFF
--- a/create_pivccu.sh
+++ b/create_pivccu.sh
@@ -4,7 +4,7 @@ CCU_VERSION=2.47.12
 CCU_DOWNLOAD_SPLASH_URL="http://www.eq-3.de/service/downloads.html?id=316"
 CCU_DOWNLOAD_URL="https://www.eq-3.de/Downloads/Software/HM-CCU2-Firmware_Updates/HM-CCU-$CCU_VERSION/HM-CCU-$CCU_VERSION.tgz"
 
-PKG_BUILD=50
+PKG_BUILD=51
 
 CURRENT_DIR=$(pwd)
 WORK_DIR=$(mktemp -d)

--- a/create_pivccu3.sh
+++ b/create_pivccu3.sh
@@ -4,7 +4,7 @@ CCU_VERSION=3.47.10
 CCU_DOWNLOAD_SPLASH_URL="http://www.eq-3.de/service/downloads.html?id=315"
 CCU_DOWNLOAD_URL="https://www.eq-3.de/Downloads/Software/CCU3-Firmware/CCU3-$CCU_VERSION/ccu3-$CCU_VERSION.tgz"
 
-PKG_BUILD=28
+PKG_BUILD=29
 
 CURRENT_DIR=$(pwd)
 WORK_DIR=$(mktemp -d)

--- a/pivccu/host/pivccu-backup.sh
+++ b/pivccu/host/pivccu-backup.sh
@@ -32,6 +32,7 @@ tar czf $TMPDIR/usr_local.tar.gz usr/local
 
 /usr/sbin/chroot $TMPDIR/root crypttool -s -t 1 < $TMPDIR/usr_local.tar.gz > $TMPDIR/signature
 /usr/sbin/chroot $TMPDIR/root crypttool -g -t 1 > $TMPDIR/key_index
+
 cp $TMPDIR/root/boot/VERSION $TMPDIR/firmware_version
 
 cd $TMPDIR

--- a/pivccu/host/pivccu-backup.sh
+++ b/pivccu/host/pivccu-backup.sh
@@ -30,8 +30,8 @@ mount --bind /var/lib/piVCCU/userfs $TMPDIR/root/usr/local
 cd $TMPDIR/root
 tar czf $TMPDIR/usr_local.tar.gz usr/local
 
-chroot $TMPDIR/root crypttool -s -t 1 < $TMPDIR/usr_local.tar.gz > $TMPDIR/signature
-chroot $TMPDIR/root crypttool -g -t 1 > $TMPDIR/key_index
+/usr/sbin/chroot $TMPDIR/root crypttool -s -t 1 < $TMPDIR/usr_local.tar.gz > $TMPDIR/signature
+/usr/sbin/chroot $TMPDIR/root crypttool -g -t 1 > $TMPDIR/key_index
 cp $TMPDIR/root/boot/VERSION $TMPDIR/firmware_version
 
 cd $TMPDIR

--- a/pivccu/host3/pivccu-backup.sh
+++ b/pivccu/host3/pivccu-backup.sh
@@ -30,8 +30,8 @@ mount --bind /var/lib/piVCCU3/userfs $TMPDIR/root/usr/local
 cd $TMPDIR/root
 tar czf $TMPDIR/usr_local.tar.gz usr/local
 
-chroot $TMPDIR/root crypttool -s -t 1 < $TMPDIR/usr_local.tar.gz > $TMPDIR/signature
-chroot $TMPDIR/root crypttool -g -t 1 > $TMPDIR/key_index
+/usr/sbin/chroot $TMPDIR/root crypttool -s -t 1 < $TMPDIR/usr_local.tar.gz > $TMPDIR/signature
+/usr/sbin/chroot $TMPDIR/root crypttool -g -t 1 > $TMPDIR/key_index
 cp $TMPDIR/root/boot/VERSION $TMPDIR/firmware_version
 
 cd $TMPDIR

--- a/pivccu/host3/pivccu-backup.sh
+++ b/pivccu/host3/pivccu-backup.sh
@@ -32,6 +32,7 @@ tar czf $TMPDIR/usr_local.tar.gz usr/local
 
 /usr/sbin/chroot $TMPDIR/root crypttool -s -t 1 < $TMPDIR/usr_local.tar.gz > $TMPDIR/signature
 /usr/sbin/chroot $TMPDIR/root crypttool -g -t 1 > $TMPDIR/key_index
+
 cp $TMPDIR/root/boot/VERSION $TMPDIR/firmware_version
 
 cd $TMPDIR


### PR DESCRIPTION
Hi,

der chroot-Befehl ist bei meiner OpenHAB Installation im Pfad /usr/sbin.
Wenn ich pivccu-backup.sh aus einem Cronjob heraus aufrufe, ist dieser Pfad nicht in der PATH-Variable hinterlegt. Ich habe daher den Aufruf des Befehls um den Pfad ergänzt.