### PR TITLE
Added 'wired' support for cubietruck

### DIFF
--- a/dts/armbian/detect_board.inc
+++ b/dts/armbian/detect_board.inc
@@ -32,6 +32,15 @@ if [ ! -z "$DEV_TREE_COMPATIBLE" ]; then
         OVERLAY_FILE='pivccu-bananapi-pro.dtbo'
         break;
         ;;
+      cubietech,cubietruck)
+	OVERLAY_MODE='overlay'
+	OVERLAY_FILE='pivccu-cubietruck.dtbo'
+	echo "TINKER ALERT: cubietruck has no RPI-Style headers"
+	echo "Overlay is using UART 7 (PI20,PI21), PB15 as reset and I2C1 (PB18,PB19) for RPI-RF-MOD (no LED support)"
+	echo "Connect as follows to CN8 (2x15) header: RX (P8) to 15, TX (P10) to 17, Reset (P12) to 11 and 3.3V/Gnd appropriately"
+	echo "Connect SDA (P3) to 25 and SCK (P5) to 23 for RPI-RF-MOD"
+	break;
+	;;
       asus,rk3288-tinker|asus,rk3288-tinker-s)
         OVERLAY_MODE='patch'
         INCLUDE_FILE='/var/lib/piVCCU/dts/tinkerboard.dts.include'

--- a/dts/pivccu-cubietruck.dts
+++ b/dts/pivccu-cubietruck.dts
@@ -1,0 +1,42 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "allwinner,sun7i-a20";
+
+        fragment@0 {
+                target-path = "/aliases";
+                __overlay__ {
+                        serial7 = "/soc@01c00000/serial@01c29c00";
+                };
+        };
+
+
+        fragment@1 {
+                target = <&uart7>;
+                __overlay__ {
+                        pinctrl-names = "default";
+                        pinctrl-0 = <&uart7_pins_a>;
+                        status = "okay";
+                        compatible = "pivccu,dw_apb";
+                        pivccu,reset_pin = <&pio 1 15 0>;
+                };
+        };
+
+        fragment@2 {
+                target = <&i2c1>;
+                __overlay__ {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                status = "okay";
+
+                rx8130@32 {
+                        compatible = "epson,rx8130-legacy";
+                        reg = <0x32>;
+                        status = "okay";
+                        enable-external-capacitor;
+                        };
+                };
+        };
+};
+


### PR DESCRIPTION
Tested for HM-MOD-RPI-PCB, but not for RPI-RF-MOD.  The latter should work in theory.
Added additional fragment for alias for UART7, as this was  done in the armbian provided overlays, not sure if it is necessary