### PR TITLE
fixed USB0

### DIFF
--- a/pivccu/host3/start_container.sh
+++ b/pivccu/host3/start_container.sh
@@ -114,7 +114,7 @@ for dev in ${devices[@]}; do
       DEVTYPE="b"
       echo "mount -t ${UDEV_PROPERTIES[ID_FS_TYPE]} -o noexec,nodev,noatime,nodiratime ${UDEV_PROPERTIES[DEVNAME]} /media/usb$USBDISKINDEX" >> /tmp/pivccu-var/pivccu/create-mounts
       mkdir -p /tmp/pivccu-media/usb$USBDISKINDEX
-      if [ ! -e /tmp/pivccu-media/usb0 ]; then
+      if [ ! -e /tmp/pivccu-media/usb$USBDISKINDEX ]; then
         ln -s /media/usb$USBDISKINDEX /tmp/pivccu-media/usb0
       fi
       mkdir -p /tmp/pivccu-var/status


### PR DESCRIPTION
When handling with muliple USB devices USB0 in start_container.sh  seems not correct. Replaced with index instead. win-ccu3 detects now USB correctly.