### PR TITLE
Fix __stack_chk_guard undefined error on Buster ARM64

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -21,6 +21,16 @@ ifeq ($(KERNEL_DIR),)
   KERNEL_DIR := /lib/modules/$(KERNELRELEASE)/build
 endif
 
+# On ARM64, enable GCC compatibility workaround if native canary handling is unavailable (Buster).
+include $(KERNEL_DIR)/scripts/Kbuild.include
+
+ifeq ($(ARCH),arm64)
+  ifeq ($(call cc-option-yn,-mstack-protector-guard=sysreg -mstack-protector-guard-reg=sp_el0 -mstack-protector-guard-offset=0),n)
+    KBUILD_CFLAGS += -DBUSTER_GCC_CANARY_WORKAROUND
+  endif
+endif
+
+
 all:
 	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules
 

--- a/kernel/buster_gcc_canary_workaround.h
+++ b/kernel/buster_gcc_canary_workaround.h
@@ -1,0 +1,17 @@
+#ifdef BUSTER_GCC_CANARY_WORKAROUND
+
+unsigned long __stack_chk_guard;
+
+void __stack_chk_guard_setup(void)
+{
+  __stack_chk_guard = 0xB233A44D;
+}
+
+void __stack_chk_fail(void)
+{
+  dump_stack ();
+  panic ("Stack-protector:kernel stack is corrupted in:%pa\n",
+    __builtin_return_address (0));
+}
+
+#endif

--- a/kernel/buster_gcc_canary_workaround.h
+++ b/kernel/buster_gcc_canary_workaround.h
@@ -4,13 +4,12 @@ unsigned long __stack_chk_guard;
 
 void __stack_chk_guard_setup(void)
 {
-  __stack_chk_guard = 0xB233A44D;
+  __stack_chk_guard = current->stack_canary;
 }
 
 void __stack_chk_fail(void)
 {
-  dump_stack ();
-  panic ("Stack-protector:kernel stack is corrupted in:%pa\n",
+  panic ("stack-protector: Kernel stack is corrupted in: %pB",
     __builtin_return_address (0));
 }
 

--- a/kernel/dw_apb_raw_uart.c
+++ b/kernel/dw_apb_raw_uart.c
@@ -34,6 +34,7 @@
 #include <linux/delay.h>
 #include <linux/version.h>
 
+#include "buster_gcc_canary_workaround.h"
 #include "generic_raw_uart.h"
 
 #define MODULE_NAME "dw_apb_raw_uart"

--- a/kernel/eq3_char_loop.c
+++ b/kernel/eq3_char_loop.c
@@ -42,6 +42,8 @@
 #include <asm/ioctls.h>
 #include <linux/version.h>
 
+#include "buster_gcc_canary_workaround.h"
+
 #define EQ3LOOP_NUMBER_OF_CHANNELS 4
 #define EQ3LOOP_DRIVER_NAME "eq3loop"
 

--- a/kernel/fake_hmrf.c
+++ b/kernel/fake_hmrf.c
@@ -38,6 +38,7 @@
 #include <asm/termios.h>
 #include <linux/delay.h>
 
+#include "buster_gcc_canary_workaround.h"
 #include "hm.h"
 
 #define DRIVER_NAME "fake-hmrf"

--- a/kernel/generic_raw_uart.c
+++ b/kernel/generic_raw_uart.c
@@ -40,6 +40,7 @@
 #include <linux/gpio/consumer.h>
 #include <linux/delay.h>
 
+#include "buster_gcc_canary_workaround.h"
 #include "generic_raw_uart.h"
 
 #define DRIVER_NAME "raw-uart"

--- a/kernel/hb_rf_eth.c
+++ b/kernel/hb_rf_eth.c
@@ -33,6 +33,7 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include <uapi/linux/sched/types.h>
 #endif
+#include "buster_gcc_canary_workaround.h"
 #include "generic_raw_uart.h"
 
 #define HB_RF_ETH_PORT 3008

--- a/kernel/hb_rf_usb-2.c
+++ b/kernel/hb_rf_usb-2.c
@@ -21,6 +21,7 @@
 #include <linux/slab.h>
 #include <linux/gpio/driver.h>
 #include <linux/version.h>
+#include "buster_gcc_canary_workaround.h"
 #include "generic_raw_uart.h"
 
 #define TX_CHUNK_SIZE 11

--- a/kernel/led_trigger_timer.c
+++ b/kernel/led_trigger_timer.c
@@ -21,6 +21,7 @@
 #include <linux/ctype.h>
 #include <linux/leds.h>
 #include <linux/version.h>
+#include "buster_gcc_canary_workaround.h"
 
 static ssize_t led_delay_on_show(struct device *dev,
 		struct device_attribute *attr, char *buf)

--- a/kernel/rpi_rf_mod_led.c
+++ b/kernel/rpi_rf_mod_led.c
@@ -26,6 +26,7 @@
 #include <linux/platform_device.h>
 #include <linux/property.h>
 #include <linux/slab.h>
+#include "buster_gcc_canary_workaround.h"
 
 static int red_gpio_pin = 0;
 static int green_gpio_pin = 0;

--- a/kernel/rtc-rx8130.c
+++ b/kernel/rtc-rx8130.c
@@ -46,6 +46,8 @@
 #include <linux/interrupt.h>
 #include <linux/input.h>
 
+#include "buster_gcc_canary_workaround.h"
+
 // RX-8130 Register definitions
 #define RX8130_REG_SEC 0x10
 #define RX8130_REG_MIN 0x11


### PR DESCRIPTION
Per raspberrypi-kernel-headers' arch/arm64/Kconfig and Makefile, `CC_HAVE_STACKPROTECTOR_SYSREG` and therefore also `STACKPROTECTOR_PER_TASK` are set on the distributed kernel as that one is built with GCC 9. In contrast, only GCC 8 is available on Buster systems, so these options are unavailable when the piVCCU modules are compiled. Therefore two functions are undefined and the build fails.

Fix this by providing standard implementations on ARM64, but only if the compiler doesn't support the relevant options.

With these changes applied, compilation works on a Raspberry Pi 4B with Raspberry Pi OS 64-bit. Didn't have a chance yet to test the kernel modules, though :(

As this is my first contact with Linux kernel sources, kbuild, DKMS, and also piVCCU, and I'm not well versed in Makefiles either, the proposed changes can disobey a lot of conventions and guidelines -- sorry for this! Feel free to change, ignore, or simply close this PR if this is way off.