### PR TITLE
changes for kernel 5.10.x compatibility

### DIFF
--- a/kernel/generic_raw_uart.c
+++ b/kernel/generic_raw_uart.c
@@ -21,6 +21,7 @@
 #include <linux/kernel.h>
 #include <linux/errno.h>
 #include <linux/module.h>
+#include <linux/property.h>
 #include <linux/device.h>
 #include <linux/slab.h>
 #include <linux/io.h>

--- a/kernel/hb_rf_eth.c
+++ b/kernel/hb_rf_eth.c
@@ -183,8 +183,12 @@ static void hb_rf_eth_set_timeout(struct socket *sock)
   struct timeval tv = { .tv_sec = 0, .tv_usec = 100000 };
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+  mm_segment_t fs = force_uaccess_begin();
+#else
   mm_segment_t fs = get_fs();
   set_fs(KERNEL_DS);
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
   sock_setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO_NEW, KERNEL_SOCKPTR((char *)&tv), sizeof(tv));
@@ -194,7 +198,11 @@ static void hb_rf_eth_set_timeout(struct socket *sock)
   sock_setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+  force_uaccess_end(fs);
+#else
   set_fs(fs);
+#endif
 }
 
 static void hb_rf_eth_send_msg(struct socket *sock, char *buffer, size_t len)

--- a/kernel/hb_rf_eth.c
+++ b/kernel/hb_rf_eth.c
@@ -183,9 +183,7 @@ static void hb_rf_eth_set_timeout(struct socket *sock)
   struct timeval tv = { .tv_sec = 0, .tv_usec = 100000 };
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
-  mm_segment_t fs = force_uaccess_begin();
-#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
   mm_segment_t fs = get_fs();
   set_fs(KERNEL_DS);
 #endif
@@ -198,9 +196,7 @@ static void hb_rf_eth_set_timeout(struct socket *sock)
   sock_setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
-  force_uaccess_end(fs);
-#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
   set_fs(fs);
 #endif
 }


### PR DESCRIPTION
* added changes to get generic_raw_uart.c (necessary property.h include) and hb_rf_eth.c (get/set_fs() has been replaced by force_uaccess_begin/end()) compiled on kernel 5.10.x