### PR TITLE
add support for banana pi m2 plus

### DIFF
--- a/dts/armbian/detect_board.inc
+++ b/dts/armbian/detect_board.inc
@@ -7,7 +7,7 @@ fi
 if [ ! -z "$DEV_TREE_COMPATIBLE" ]; then
   for str in $DEV_TREE_COMPATIBLE; do
     case $str in
-      xunlong,orangepi-one|xunlong,orangepi-lite|xunlong,orangepi-plus|xunlong,orangepi-plus2e|xunlong,orangepi-2|xunlong,orangepi-pc|xunlong,orangepi-pc-plus,bpi-m2-plusallwinner)
+      xunlong,orangepi-one|xunlong,orangepi-lite|xunlong,orangepi-plus|xunlong,orangepi-plus2e|xunlong,orangepi-2|xunlong,orangepi-pc|xunlong,orangepi-pc-plus|sinovoip,bpi-m2-plus)
         OVERLAY_MODE='overlay'
         OVERLAY_FILE='pivccu-orangepi-h3.dtbo'
         break

--- a/dts/armbian/detect_board.inc
+++ b/dts/armbian/detect_board.inc
@@ -7,7 +7,7 @@ fi
 if [ ! -z "$DEV_TREE_COMPATIBLE" ]; then
   for str in $DEV_TREE_COMPATIBLE; do
     case $str in
-      xunlong,orangepi-one|xunlong,orangepi-lite|xunlong,orangepi-plus|xunlong,orangepi-plus2e|xunlong,orangepi-2|xunlong,orangepi-pc|xunlong,orangepi-pc-plus|sinovoip,bpi-m2-plus)
+      xunlong,orangepi-one|xunlong,orangepi-lite|xunlong,orangepi-plus|xunlong,orangepi-plus2e|xunlong,orangepi-2|xunlong,orangepi-pc|xunlong,orangepi-pc-plus)
         OVERLAY_MODE='overlay'
         OVERLAY_FILE='pivccu-orangepi-h3.dtbo'
         break
@@ -30,6 +30,11 @@ if [ ! -z "$DEV_TREE_COMPATIBLE" ]; then
       lemaker,bananapro)
         OVERLAY_MODE='overlay'
         OVERLAY_FILE='pivccu-bananapi-pro.dtbo'
+        break;
+        ;;
+      sinovoip,bpi-m2-plus)
+        OVERLAY_MODE='overlay'
+        OVERLAY_FILE='pivccu-bananapi-m2-plus.dtbo'
         break;
         ;;
       asus,rk3288-tinker|asus,rk3288-tinker-s)

--- a/dts/armbian/detect_board.inc
+++ b/dts/armbian/detect_board.inc
@@ -7,7 +7,7 @@ fi
 if [ ! -z "$DEV_TREE_COMPATIBLE" ]; then
   for str in $DEV_TREE_COMPATIBLE; do
     case $str in
-      xunlong,orangepi-one|xunlong,orangepi-lite|xunlong,orangepi-plus|xunlong,orangepi-plus2e|xunlong,orangepi-2|xunlong,orangepi-pc|xunlong,orangepi-pc-plus)
+      xunlong,orangepi-one|xunlong,orangepi-lite|xunlong,orangepi-plus|xunlong,orangepi-plus2e|xunlong,orangepi-2|xunlong,orangepi-pc|xunlong,orangepi-pc-plus,bpi-m2-plusallwinner)
         OVERLAY_MODE='overlay'
         OVERLAY_FILE='pivccu-orangepi-h3.dtbo'
         break

--- a/dts/pivccu-bananapi-m2-plus.dts
+++ b/dts/pivccu-bananapi-m2-plus.dts
@@ -12,9 +12,11 @@
       status = "okay";
       compatible = "pivccu,dw_apb";
       pivccu,reset_pin = <&pio 0 16 0>;
-      pivccu,red_pin = <&pio 6 9 0>;
-      pivccu,green_pin = <&pio 6 6 0>;
-      pivccu,blue_pin = <&pio 6 7 0>;
+      pivccu,alt_reset_pin = <&pio 0 10 0>;
+      pivccu,red_pin = <&pio 7 4 0>;
+      pivccu,green_pin = <&pio 0 21 0>;
+      pivccu,blue_pin = <&pio 0 20 0>;
+      pivccu,rtc = <&rpi_rf_mod_rtc>;
     };
   };
 

--- a/dts/pivccu-bananapi-m2-plus.dts
+++ b/dts/pivccu-bananapi-m2-plus.dts
@@ -1,0 +1,37 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+  compatible = "allwinner,sun8i-h3";
+
+  fragment@0 {
+    target = <&uart3>;
+    __overlay__ {
+      pinctrl-names = "default";
+      pinctrl-0 = <&uart3_pins>;
+      status = "okay";
+      compatible = "pivccu,dw_apb";
+      pivccu,reset_pin = <&pio 0 16 0>;
+      pivccu,red_pin = <&pio 6 9 0>;
+      pivccu,green_pin = <&pio 6 6 0>;
+      pivccu,blue_pin = <&pio 6 7 0>;
+    };
+  };
+
+
+  fragment@1 {
+    target = <&i2c0>;
+    __overlay__ {
+      #address-cells = <1>;
+      #size-cells = <0>;
+      status = "okay";
+
+      rx8130@32 {
+        compatible = "epson,rx8130-legacy";
+        reg = <0x32>;
+        status = "okay";
+        enable-external-capacitor;
+      };
+    };
+  };
+};


### PR DESCRIPTION
add support for banana pi m2 plus a " more or less a clone of Orange Pi PC/Plus"(https://linux-sunxi.org/Sinovoip_Banana_Pi_M2%2B)
tested and works on my  banana pi m2 plus with  Armbian 21.02.3 Focal with Linux 5.10.21-sunxi and a HM-MOD-RPI-PCB connected to gpio header 