### PR TITLE
Static MAC for container

### DIFF
--- a/pivccu/host/lxc.config
+++ b/pivccu/host/lxc.config
@@ -17,7 +17,7 @@ lxc.mount.entry = /var/lib/piVCCU/sdcardfs media/sd-mmcblk0/ none defaults,bind 
 lxc.network.type = veth
 lxc.network.flags = up
 lxc.network.link = <bridge_auto>
-lxc.network.hwaddr = <mac_auto>
+lxc.network.hwaddr = 0a:aa:31:41:59:26
 lxc.network.veth.pair = vethpivccu
 
 lxc.cgroup.devices.deny = a


### PR DESCRIPTION
Hi,

when the CCU container is configured to receive its IP via DHCP, the assignment of a static IP via DHCP is not possible as the container currently regenerates a random MAC address each time the container / pivccu service is restarted.

As for many applications a static IP is necessary (XML-API, DNS in general, ...), a static MAC fixes this.

My change sets the container MAC address to a static value. The address is taken from a locally administered address range so it should not cause conflicts with existing devices.

For the future, it might be also worth considering to use a MAC that is once random-generated (e.g. at install / first boot) and then kept static, preventing issues with multiple piVCCU instances in the same network.