### PR TITLE
Run depmod in ensure_modules.sh

### DIFF
--- a/pivccu/dkms/ensure_modules.sh
+++ b/pivccu/dkms/ensure_modules.sh
@@ -30,7 +30,17 @@ if [ ! $? -eq 0 ]; then
     fi
   fi
 
-  dkms install -m pivccu -v $PKG_VER -k `uname -r` || true
+  if [[ ! "$(dkms status -m pivccu -v $PKG_VER -k `uname -r`)" =~ "installed" ]]; then
+    dkms install -m pivccu -v $PKG_VER -k `uname -r` || true
+  else
+    if [ "$(uname -s)" == "Linux" ] ; then
+      if [[ -f /boot/System.map-`uname -r` ]]; then
+        depmod -a "$(uname -r)" -F "/boot/System.map-$(uname -r)"
+      else
+        depmod -a "$(uname -r)"
+      fi
+    fi
+  fi
 
   modinfo generic_raw_uart &> /dev/null
   if [ $? -eq 0 ]; then


### PR DESCRIPTION
Per issue #368, running `depmod` unconditionally works around the situation I encountered yesterday. Tested on a Raspberry Pi 4B on arm64 with the following sequence of commands:

```
# Reproduce the situation
pi@vraspi:~ $ sudo dkms uninstall pivccu/1.0.63
pi@vraspi:~ $ sudo dkms install pivccu/1.0.63 --no-depmod

# Try to run piVCCU
pi@vraspi:~ $ sudo systemctl start pivccu.service
```

That fails with the same error:

```
pi@vraspi:~ $ journalctl -u pivccu
...
Sep 06 09:26:54 vraspi systemd[1]: Starting piVCCU...
Sep 06 09:26:54 vraspi start_container.sh[5194]: grep: /local/lib/udev/rules.d/: Datei oder Verzeichnis nicht gefunden
Sep 06 09:26:54 vraspi start_container.sh[5194]: grep: /run/udev/rules.d/: Datei oder Verzeichnis nicht gefunden
Sep 06 09:26:54 vraspi start_container.sh[5194]: modprobe: FATAL: Module eq3_char_loop not found in directory /lib/modules/5.10.60-v8+
Sep 06 09:26:59 vraspi start_container.sh[5194]: /var/lib/piVCCU3/detect_hardware.inc: Zeile 43: /sys/module/fake_hmrf/parameters/firmware_version: Datei oder Verzeichnis nicht gefunden
Sep 06 09:26:59 vraspi start_container.sh[5194]: grep: Schreibfehler: Datenübergabe unterbrochen (broken pipe)
Sep 06 09:26:59 vraspi start_container.sh[5194]: cat: /sys/module/fake_hmrf/parameters/firmware_version: Datei oder Verzeichnis nicht gefunden
Sep 06 09:27:02 vraspi start_container.sh[5194]: modprobe: FATAL: Module rpi_rf_mod_led not found in directory /lib/modules/5.10.60-v8+
Sep 06 09:27:05 vraspi start_container.sh[5194]: kernel.sched_rt_runtime_us = -1
Sep 06 09:27:05 vraspi start_container.sh[5194]: lxc-start: lxc: lxccontainer.c: wait_on_daemonized_start: 842 Received container state "ABORTING" instead of "RUNNING"
Sep 06 09:27:05 vraspi start_container.sh[5194]: lxc-start: lxc: tools/lxc_start.c: main: 330 The container failed to start
Sep 06 09:27:05 vraspi start_container.sh[5194]: lxc-start: lxc: tools/lxc_start.c: main: 333 To get more details, run the container in foreground mode
Sep 06 09:27:05 vraspi start_container.sh[5194]: lxc-start: lxc: tools/lxc_start.c: main: 336 Additional information can be obtained by setting the --logfile and --logpriority options
Sep 06 09:27:05 vraspi systemd[1]: pivccu.service: Can't open PID file /run/pivccu3.pid (yet?) after start: No such file or directory
Sep 06 09:31:54 vraspi systemd[1]: pivccu.service: Start operation timed out. Terminating.
Sep 06 09:31:54 vraspi systemd[1]: pivccu.service: Failed with result 'timeout'.
Sep 06 09:31:54 vraspi systemd[1]: Failed to start piVCCU.
```

Applied this PR and ran the following commands:

```
pi@vraspi:~ $ sudo systemctl restart pivccu-dkms.service
pi@vraspi:~ $ sudo systemctl start pivccu.service
pi@vraspi:~ $
```

Now piVCCU is running:

```
Sep 06 09:38:10 vraspi systemd[1]: Starting piVCCU...
Sep 06 09:38:10 vraspi start_container.sh[8024]: grep: /local/lib/udev/rules.d/: Datei oder Verzeichnis nicht gefunden
Sep 06 09:38:10 vraspi start_container.sh[8024]: grep: /run/udev/rules.d/: Datei oder Verzeichnis nicht gefunden
Sep 06 09:38:15 vraspi start_container.sh[8024]: kernel.sched_rt_runtime_us = -1
Sep 06 09:38:15 vraspi systemd[1]: Started piVCCU.
```

So, this PR resolves #368.