### PR TITLE
Adapt to debian

### DIFF
--- a/create_modules_dkms.sh
+++ b/create_modules_dkms.sh
@@ -53,7 +53,7 @@ done
 
 cd $WORK_DIR
 
-dpkg-deb --build pivccu-modules-dkms-$PKG_VERSION
+fakeroot dpkg-deb --build pivccu-modules-dkms-$PKG_VERSION
 
 cp pivccu-modules-dkms-*.deb $CURRENT_DIR
 

--- a/create_modules_raspberrypi.sh
+++ b/create_modules_raspberrypi.sh
@@ -29,7 +29,7 @@ done
 
 cd $WORK_DIR
 
-dpkg-deb --build pivccu-modules-raspberrypi-$PKG_VERSION
+fakeroot dpkg-deb --build pivccu-modules-raspberrypi-$PKG_VERSION
 
 cp pivccu-modules-raspberrypi-*.deb $CURRENT_DIR
 

--- a/docs/setup/raspberrypi.md
+++ b/docs/setup/raspberrypi.md
@@ -104,6 +104,7 @@
    * To use Wireless LAN, please take a look [here](wlan.md)
 
 9. Check systemd settings
+
    Some systemd services like pivccu-rpi-modules.service are depending on network-online.target to ensure that the network is *really* online.
    But in Raspberry Pi OS this is not configured out of the box.
    Required settings are depending on the network configuration method.

--- a/package/pivccu-modules-raspberrypi/config
+++ b/package/pivccu-modules-raspberrypi/config
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+db_input critical pivccu/configure_kernel || true
+db_go

--- a/package/pivccu-modules-raspberrypi/control
+++ b/package/pivccu-modules-raspberrypi/control
@@ -2,7 +2,7 @@ Package: pivccu-modules-raspberrypi
 Version: {PKG_VERSION}
 Architecture: all
 Maintainer: Alexander Reinert <alex@areinert.de>
-Depends: raspberrypi-kernel-headers | linux-headers-raspi, pivccu-modules-dkms, bc
+Depends: raspberrypi-kernel-headers | linux-headers-raspi | linux-headers-arm64, pivccu-modules-dkms, bc
 Pre-Depends: debconf (>= 0.5) | debconf-2.0
 Section: kernel
 Priority: extra

--- a/package/pivccu-modules-raspberrypi/control
+++ b/package/pivccu-modules-raspberrypi/control
@@ -2,7 +2,7 @@ Package: pivccu-modules-raspberrypi
 Version: {PKG_VERSION}
 Architecture: all
 Maintainer: Alexander Reinert <alex@areinert.de>
-Depends: raspberrypi-kernel-headers | linux-headers-raspi | linux-headers-arm64, pivccu-modules-dkms, bc
+Depends: raspberrypi-kernel-headers | linux-headers-raspi | linux-headers-arm64, pivccu-modules-dkms, bc, libssl-dev
 Pre-Depends: debconf (>= 0.5) | debconf-2.0
 Section: kernel
 Priority: extra

--- a/package/pivccu-modules-raspberrypi/postinst
+++ b/package/pivccu-modules-raspberrypi/postinst
@@ -34,6 +34,7 @@ case "$1" in
         CFG_KERNEL=" -c"
       fi
       sed -i -r "s|^(ExecStart=.*ensure_headers\.sh).*|\1${CFG_KERNEL}|" /usr/lib/systemd/system/pivccu-rpi-modules.service
+      systemctl daemon-reload
     fi
     ;;
 

--- a/package/pivccu-modules-raspberrypi/postinst
+++ b/package/pivccu-modules-raspberrypi/postinst
@@ -26,9 +26,17 @@ case "$1" in
         db_go
       fi
     fi
+
+    if [ -f /usr/lib/systemd/system/pivccu-rpi-modules.service ]; then
+      CFG_KERNEL=""
+      db_get pivccu/configure_kernel
+      if [ "$RET" = "true" ]; then
+        CFG_KERNEL=" -c"
+      fi
+      sed -i -r "s|^(ExecStart=.*ensure_headers\.sh).*|\1${CFG_KERNEL}|" /usr/lib/systemd/system/pivccu-rpi-modules.service
+    fi
     ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)
     ;;
 esac
-

--- a/package/pivccu-modules-raspberrypi/preinst
+++ b/package/pivccu-modules-raspberrypi/preinst
@@ -5,17 +5,17 @@ set -e
 case "$1" in
   install|upgrade)
     mkdir -p /var/lib/piVCCU/dtb
-    if [[ -d /boot/firmware/overlays ]]; then
+    if [[ -d /boot/firmware ]]; then
+      mkdir -p /boot/firmware/overlays
       mount --bind /boot/firmware /var/lib/piVCCU/dtb
     elif [[ -d /boot/overlays ]]; then
       mount --bind /boot /var/lib/piVCCU/dtb
     fi
 
     mkdir -p /usr/share/rpikernelhack/overlays
-    dpkg-divert --package rpikernelhack --divert /usr/share/rpikernelhack/overlays/pivccu-raspberrypi.dtbo /var/lib/piVCCU/dtb/overlays/pivccu-raspberrypi.dtbo
+    dpkg-divert --package rpikernelhack --no-rename --divert /usr/share/rpikernelhack/overlays/pivccu-raspberrypi.dtbo /var/lib/piVCCU/dtb/overlays/pivccu-raspberrypi.dtbo
     ;;
 
   abort-upgrade)
     ;;
 esac
-

--- a/package/pivccu-modules-raspberrypi/templates
+++ b/package/pivccu-modules-raspberrypi/templates
@@ -2,3 +2,8 @@ Template: pivccu/reboot_required
 Type: note
 Description: WARNING: A reboot is required to enable the modules.
 Description-DE: WARNUNG: Ein Neustart ist erforderlich um die Module zu aktivieren.
+
+Template: pivccu/configure_kernel
+Type: boolean
+Description: Enable kernel configuration after kernel download?
+Description-DE: Kernel-Konfiguration nach Kernel-Download aktivieren?

--- a/pivccu/rpi-modules/ensure_headers.sh
+++ b/pivccu/rpi-modules/ensure_headers.sh
@@ -48,7 +48,8 @@ if [ -f /boot/.firmware_revision ]; then
     KERNEL="kernel$ARM_VER"
     cd $MODULE_DIR/source
     modprobe configs &> /dev/null
-    zcat /proc/config.gz > $MODULE_DIR/source/.config
+    zcat /proc/config.gz > .config
+    make olddefconfig
     make modules_prepare > /dev/null
   fi
 else

--- a/pivccu/rpi-modules/ensure_headers.sh
+++ b/pivccu/rpi-modules/ensure_headers.sh
@@ -49,7 +49,7 @@ if [ -f /boot/.firmware_revision ]; then
     cd $MODULE_DIR/source
     modprobe configs &> /dev/null
     zcat /proc/config.gz > .config
-    make olddefconfig
+    make olddefconfig > /dev/null
     make modules_prepare > /dev/null
   fi
 else

--- a/pivccu/rpi-modules/ensure_headers.sh
+++ b/pivccu/rpi-modules/ensure_headers.sh
@@ -49,7 +49,7 @@ if [ -f /boot/.firmware_revision ]; then
     cd $MODULE_DIR/source
     modprobe configs &> /dev/null
     zcat /proc/config.gz > $MODULE_DIR/source/.config
-    make modules_prepare
+    make modules_prepare > /dev/null
   fi
 else
   echo "Could not determine kernel source."


### PR DESCRIPTION
My main intention was to support Debian. But I optimized some details to support 64 bit versions of Raspberry Pi OS too.

- Added fakeroot to create_modules_*.
- Added an option to enable/disable kernel configuration after download (to save some time).
- Added dependency of linux-headers-arm64 to support Debian.
- Minor changes in preinst script to support Debian.
- Changes in ensure_headers.sh to support 32 and 64 bit kernels and optional skipping kernel configuration.
- Added some important steps to documentation.

I checked my changes with following systems (on Raspberry Pi 3B):

- Raspberry Pi OS 32 bit
- Raspberry Pi OS 64 bit
- Ubuntu 20.04.3 64 bit