### PR TITLE
Minor fixes for detecting the hardware

### DIFF
--- a/pivccu/host3/detect_hardware.inc
+++ b/pivccu/host3/detect_hardware.inc
@@ -84,6 +84,7 @@ case "$PIVCCU_RF_MODE" in
     for syspath in $(find /sys/bus/usb/devices/); do
       if [ ! -e $syspath/idVendor ]; then
         continue
+	  fi
 
       USBID="`cat $syspath/idVendor`:`cat $syspath/idProduct`"
 
@@ -110,7 +111,6 @@ case "$PIVCCU_RF_MODE" in
             sleep 1
           done
         fi
-      fi
 
       for try in {0..30}; do
           if [ $(find $syspath/ -mindepth 2 -name driver | wc -l) -ne 0 ]; then

--- a/pivccu/host3/detect_hardware.inc
+++ b/pivccu/host3/detect_hardware.inc
@@ -128,7 +128,7 @@ case "$PIVCCU_RF_MODE" in
         UART_DEV="raw-uart$dev_no"
       fi
 
-      if [ -e "/sys/devices/virtual/raw-uart/$UART_DEV" ]; then
+      if [ -e "/sys/class/raw-uart/$UART_DEV" ]; then
         if [ ! -e "/dev/$UART_DEV" ]; then
           mknod "/dev/$UART_DEV" c `cat /sys/devices/virtual/raw-uart/$UART_DEV/dev | tr ':' ' '`
         fi


### PR DESCRIPTION
This pull requests does fixes what seems to be a simple misplaced fi.
Moreover, it uses /sys/class/ to detect the correct raw-device. /sys/devices/virtual does not exist on every kernel (5.10.92-v7l+).