### PR TITLE
Fix the apt-key deprecation

### DIFF
--- a/docs/setup/armbian.md
+++ b/docs/setup/armbian.md
@@ -8,12 +8,12 @@
 0. Create full backup of your SD card
 1. Add the public key of the repository
    ```bash
-   wget -q -O - https://www.pivccu.de/piVCCU/public.key | sudo apt-key add -
+   wget -q -O - https://www.pivccu.de/piVCCU/public.key | sudo gpg --dearmor -o /usr/share/keyrings/pivccu-archive-keyring.gpg
    ```
 
 2. Add the package repository
    ```bash
-   sudo bash -c 'echo "deb https://www.pivccu.de/piVCCU stable main" > /etc/apt/sources.list.d/pivccu.list'
+   sudo bash -c 'echo "deb [signed-by=/usr/share/keyrings/pivccu-archive-keyring.gpg] https://www.pivccu.de/piVCCU stable main" > /etc/apt/sources.list.d/pivccu.list'
    sudo apt update
    ```
    Instead of `stable` you can also use the `testing` tree, but be aware testing sometimes means not that stable.


### PR DESCRIPTION
apt-key add  is depcrated   and will be last aviable in  Ubuntu 22.04 and  Debian 11
tested on recent armbian 22.11.1 with jammy userland