### PR TITLE
feat: added odroid n2+ support

### DIFF
--- a/dts/armbian/detect_board.inc
+++ b/dts/armbian/detect_board.inc
@@ -62,6 +62,12 @@ if [ ! -z "$DEV_TREE_COMPATIBLE" ]; then
         FDT_FILE='amlogic/meson-sm1-odroid-c4.dtb'
         break
         ;;
+      hardkernel,odroid-n2-plus)
+        OVERLAY_MODE='patch'
+        INCLUDE_FILE='/var/lib/piVCCU/dts/odroidn2-plus.dts.include'
+        FDT_FILE='amlogic/meson-g12b-odroid-n2-plus.dtb'
+        break
+        ;;
       libretech,cc|libretech,aml-s905x-cc)
         OVERLAY_MODE='patch'
         INCLUDE_FILE='/var/lib/piVCCU/dts/lepotato.dts.include'

--- a/dts/odroidn2-plus.dts.include
+++ b/dts/odroidn2-plus.dts.include
@@ -1,0 +1,38 @@
+/ {
+  soc {
+    bus@ff600000 {
+      bus@34400 {
+        pinctrl@40 {
+          pivccu_gpio: bank@40 {
+          };
+          pivccu_uart_a_pins: uart-a {
+          };
+        };
+      };
+    };
+
+    bus@ffd00000 {
+      serial@24000 {
+        pinctrl-0 = <&pivccu_uart_a_pins>;
+        pinctrl-names = "default";
+        status = "okay";
+        compatible = "pivccu,meson";
+        pivccu,reset-gpios = <&pivccu_gpio 81 0>, <&pivccu_gpio 84 0>;
+        pivccu,rtc = <&rpi_rf_mod_rtc>;
+      };
+
+      i2c@1d000 {
+        status = "okay";
+
+        rpi_rf_mod_rtc: rx8130@32 {
+          compatible = "epson,rx8130-legacy";
+          reg = <0x32>;
+          status = "okay";
+          aux-voltage-chargeable = <1>;
+          enable-external-capacitor;
+        };
+      };
+    };
+  };
+};
+


### PR DESCRIPTION
This commit adds support for GPIO based RF modules on ODROID N2+ boards. The overlay is basically the same as the one from ODROID's C4 boards. Tested with HM-MOD-RPI-PCB and working fine.