### PR TITLE
feat: prevent version check from blocking the service

### DIFF
--- a/pivccu/host3/start_container.sh
+++ b/pivccu/host3/start_container.sh
@@ -176,7 +176,7 @@ fi
 
 OS_RELEASE=${OS_ID}_${VERSION_CODENAME}
 
-wget -O /dev/null -q --timeout=5 "https://www.pivccu.de/latestVersion?version=$PIVCCU_VERSION&product=HM-CCU3&serial=$HM_HMIP_SERIAL&os=$OS_RELEASE&board=$BOARD_TYPE" || true
+wget -O /dev/null -q --timeout=5 --tries=1 "https://www.pivccu.de/latestVersion?version=$PIVCCU_VERSION&product=HM-CCU3&serial=$HM_HMIP_SERIAL&os=$OS_RELEASE&board=$BOARD_TYPE" || true
 
 sysctl -w kernel.sched_rt_runtime_us=-1
 


### PR DESCRIPTION
At the moment the wget call to check for latest version is configured without the tries option. This may result in a longer delay for the service to start up.