### PR TITLE
add documentation for DietPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ piVCCU is a project to install the original Homematic CCU3 firmware inside a vir
 * Support for backup/restore between piVCCU and original CCU3 without modification
 * Easy to install and update with apt
 * Support not only on Raspberry
-* Support for 
+* Support for
   * HM-MOD-RPI-PCB (HmRF+HmIP),
   * RPI-RF-MOD (HmRF+HmIP, Pushbutton is not supported)
   * HmIP-RFUSB (HmRF+HmIP)
@@ -62,7 +62,7 @@ Login to Armbian based images using user 'root' and password '1234'.
 
 ### Manual installation
 * [Raspberry Pi](docs/setup/raspberrypi.md)
-* [Armbian](docs/setup/armbian.md)
+* [Armbian](docs/setup/armbian.md) / [DietPi](docs/setup/dietpi.md)
 * [Other OS](docs/setup/otheros.md)
 
 ### Updating piVCCU to latest version
@@ -123,7 +123,7 @@ To restore a backup file use the WebUI of the CCU.
 * Original CCU3
   You can only migrate to piVCCU3.
   Just restore a normal system backup using the CCU web interface.
-   
+
 * RaspberryMatic
    1. Restore a normal system backup using the CCU web interface
    2. Reinstall all addons using the CCU web interface
@@ -211,7 +211,7 @@ To restore a backup file use the WebUI of the CCU.
          ```
       8. As the CCU3 firmware does a cherry picking of files beeing restored, you maybe need to restore some files by yourself (e.g. CUxD settings files).
       9. If you used YAHM without radio module, you should check your interface assignments of the LAN Gateways in the control panel
-      
+
 ### Using USB devices inside container (e.g. for CUxD)
 You can configure the USB devices using the installer. You can change it later using
 ```bash
@@ -233,4 +233,3 @@ The generated CCU container .deb files (pivccu) are containing the original CCU3
 
 ### Acknowledgement
 The base idea of piVCCU is inspired by [YAHM](https://github.com/leonsio/YAHM/) and [lxccu](https://www.lxccu.com/).
-

--- a/docs/setup/dietpi.md
+++ b/docs/setup/dietpi.md
@@ -1,0 +1,90 @@
+### Prequisites
+
+* DietPi
+* At least kernel 4.14 (Mainline is prefered)
+* The HM-MOD-RPI-PCB and the RPI-RF-MOD are only working on supported platforms
+
+### Installation
+0. Create full backup of your SD card
+1. Add the public key of the repository
+   ```bash
+   wget -q -O - https://apt.pivccu.de/piVCCU/public.key | sudo tee /usr/share/keyrings/pivccu.asc
+   ```
+
+2. Add the package repository
+   ```bash
+   echo "deb [signed-by=/usr/share/keyrings/pivccu.asc] https://apt.pivccu.de/piVCCU stable main" | sudo tee /etc/apt/sources.list.d/pivccu.list
+   sudo apt update
+   ```
+   Instead of `stable` you can also use the `testing` tree, but be aware testing sometimes means not that stable.
+
+3. Install the matching kernel headers
+   ```bash
+   sudo apt install build-essential bison flex libssl-dev
+   sudo apt install `dpkg --get-selections | grep 'linux-image-' | grep '\sinstall' | sed -e 's/linux-image-\([a-z0-9-]\+\).*/linux-headers-\1/'`
+   ```
+
+4. If you are using a HB-RF-ETH, install the neccessary support package
+   ```bash
+   sudo apt install hb-rf-eth
+   ```
+
+5. Install the neccessary device tree patches (You can skip this step, if you do not use the HM-MOD-RPI-PCB or RPI-RF-MOD on GPIO header, for the HB-RF-USB(-2) and HB-RF-ETH this step is not neccessary)
+   ```bash
+   sudo ln -sf /boot/dietpiEnv.txt /boot/armbianEnv.txt
+   sudo apt install pivccu-devicetree-armbian device-tree-compiler
+   ```
+
+6. Install the neccessary kernel modules
+   ```bash
+   sudo apt install pivccu-modules-dkms
+   ```
+
+7. Add network bridge (if you are using wifi please refer to the debian documentation how to configure the network and the bridge)
+  * Verify, that *eth0* is the name of your primary network interface:
+     ```bash
+     sudo ip link show | cut -d' ' -f2 | cut -d: -f1 | grep -e '^e.*'
+     ```
+
+  * Update your config. (Replace *eth0* if necessary)
+     ```bash
+     sudo apt install bridge-utils
+     sudo bash -c 'cat << EOT > /etc/network/interfaces.d/pivccu
+     iface eth0 inet manual
+
+     auto br0
+     iface br0 inet dhcp
+       bridge_ports eth0
+     EOT'
+     ```
+  * You can use an static IP address, too. In that case use instead:
+     ```bash
+     sudo apt install bridge-utils
+     sudo bash -c 'cat << EOT > /etc/network/interfaces.d/pivccu
+     iface eth0 inet manual
+
+     auto br0
+     iface br0 inet static
+       bridge_ports eth0
+       address <address>
+       netmask <netmask>
+       gateway <gateway>
+       dns-nameservers <dns1> <dns2>
+     EOT'
+     ```
+  * To use Wireless LAN, please take a look [here](wlan.md)
+
+8. Reboot the system
+   ```bash
+   sudo reboot
+   ```
+
+9. Install CCU container
+   ```bash
+   sudo apt install pivccu3
+   ```
+
+10. Start using your new virtualized CCU, you can get the IP of the container using
+   ```bash
+   sudo pivccu-info
+   ```


### PR DESCRIPTION
DietPi ist eine abgespeckte Version von Armbian. Die Hauptunterschiede bei der Installation im Vgl. zu Armbian sind:
- umbenannte Env-Datei: /boot/dietpiEnv.txt (statt /boot/armbianEnv.txt)
- Einrichtung der Netzwerkbrücke über /etc/network/interfaces statt nmcli
