### PR TITLE
Linux 6.11 compatibility

### DIFF
--- a/kernel/generic_raw_uart.h
+++ b/kernel/generic_raw_uart.h
@@ -116,19 +116,18 @@ extern bool generic_raw_uart_verify_dkey(struct device *dev, unsigned char *dkey
     return 0;                                                                             \
   }                                                                                       \
                                                                                           \
-  static int __##__raw_uart_driver##_remove(struct platform_device *pdev)                 \
+  static void __##__raw_uart_driver##_remove(struct platform_device *pdev)                \
   {                                                                                       \
     int err;                                                                              \
     struct device *dev = &pdev->dev;                                                      \
                                                                                           \
-    err = generic_raw_uart_remove(__raw_uart_driver##_raw_uart); \
+    err = generic_raw_uart_remove(__raw_uart_driver##_raw_uart);                          \
     if (err)                                                                              \
     {                                                                                     \
       dev_err(dev, "failed to remove generic_raw_uart module");                           \
-      return err;                                                                         \
     }                                                                                     \
                                                                                           \
-    return __raw_uart_driver##_remove(pdev);                                              \
+    __raw_uart_driver##_remove(pdev);                                                     \
   }                                                                                       \
                                                                                           \
   static struct platform_driver __raw_uart_driver_platform_driver = {                     \

--- a/kernel/hb_rf_eth.c
+++ b/kernel/hb_rf_eth.c
@@ -759,7 +759,7 @@ static int __init hb_rf_eth_init(void)
   gc.base = -1;
   gc.can_sleep = false;
 
-  err = gpiochip_add(&gc);
+  err = gpiochip_add_data(&gc, NULL);
   if (err)
     goto failed_gc_create;
 


### PR DESCRIPTION
Hi,

This adds support for linux kernel 6.11.
This kernel has 2 breaking changes that made `sudo dpkg-reconfigure pivccu-modules-dkms` fail as it couldn't compile the kernel module.
With the changes it works for me on a Ubuntu Server 24.10 VM (kernel 6.11.0-8-generic) using raspberrymatic in docker with the HB-RF-ETH.

In `kernel/generic_raw_uart.h` the function `__##__raw_uart_driver##_remove` had to be changed from `int` to `void` because of this kernel commit:
```diff
commit 0edb555a65d1ef047a9805051c36922b52a38a9d
Author: Uwe Kleine-König <u.kleine-koenig@pengutronix.de>
Date:   Mon Oct 9 12:37:26 2023 +0200

    platform: Make platform_driver::remove() return void
    
    struct platform_driver::remove returning an integer made driver authors
    expect that returning an error code was proper error handling. However
    the driver core ignores the error and continues to remove the device
    because there is nothing the core could do anyhow and reentering the
    remove callback again is only calling for trouble.
    
    To prevent such wrong assumptions, change the return type of the remove
    callback to void. This was prepared by introducing an alternative remove
    callback returning void and converting all drivers to that. So .remove()
    can be changed without further changes in drivers.
    
    This corresponds to step b) of the plan outlined in commit
    5c5a7680e67b ("platform: Provide a remove callback that returns no value").
    
    Signed-off-by: Uwe Kleine-König <u.kleine-koenig@pengutronix.de>

diff --git a/include/linux/platform_device.h b/include/linux/platform_device.h
index 7a41c72c1959..d422db6eec63 100644
--- a/include/linux/platform_device.h
+++ b/include/linux/platform_device.h
@@ -237,15 +237,14 @@ struct platform_driver {
        int (*probe)(struct platform_device *);
 
        /*
-        * Traditionally the remove callback returned an int which however is
-        * ignored by the driver core. This led to wrong expectations by driver
-        * authors who thought returning an error code was a valid error
-        * handling strategy. To convert to a callback returning void, new
-        * drivers should implement .remove_new() until the conversion it done
-        * that eventually makes .remove() return void.
+        * .remove_new() is a relic from a prototype conversion of .remove().
+        * New drivers are supposed to implement .remove(). Once all drivers are
+        * converted to not use .remove_new any more, it will be dropped.
         */
-       int (*remove)(struct platform_device *);
-       void (*remove_new)(struct platform_device *);
+       union {
+               void (*remove)(struct platform_device *);
+               void (*remove_new)(struct platform_device *);
+       };
 
        void (*shutdown)(struct platform_device *);
        int (*suspend)(struct platform_device *, pm_message_t state);

```

In `kernel/hb_rf_eth.c` we need to use gpiochip_add_data as gpiochip_add was removed in this kernel commit:
```diff
commit 3ff1180a39fbc43ae69d4238e6922c57e3278910
Author: Andrew Davis <afd@ti.com>
Date:   Mon Jun 10 08:53:13 2024 -0500

    gpiolib: Remove data-less gpiochip_add() function
    
    GPIO chips should be added with driver-private data associated with the
    chip. If none is needed, NULL can be used. All users already do this
    except one, fix that here. With no more users of the base gpiochip_add()
    we can drop this function so no more users show up later.
    
    Signed-off-by: Andrew Davis <afd@ti.com>
    Acked-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
    Link: https://lore.kernel.org/r/20240610135313.142571-1-afd@ti.com
    Signed-off-by: Bartosz Golaszewski <bartosz.golaszewski@linaro.org>

diff --git a/include/linux/gpio/driver.h b/include/linux/gpio/driver.h
index 0032bb6e7d8f..6d31388dde0a 100644
--- a/include/linux/gpio/driver.h
+++ b/include/linux/gpio/driver.h
@@ -632,10 +632,6 @@ int gpiochip_add_data_with_key(struct gpio_chip *gc, void *data,
        devm_gpiochip_add_data_with_key(dev, gc, data, NULL, NULL)
 #endif /* CONFIG_LOCKDEP */
 
-static inline int gpiochip_add(struct gpio_chip *gc)
-{
-       return gpiochip_add_data(gc, NULL);
-}
 void gpiochip_remove(struct gpio_chip *gc);
 int devm_gpiochip_add_data_with_key(struct device *dev, struct gpio_chip *gc,
                                    void *data, struct lock_class_key *lock_key,
```

The old function calls should probably be left in there so it would still compile on older kernels, but I don't know how to do that...
Also i'm not sure if those kernel changes were introduced with 6.11 or in earlier versions.