### PR TITLE
Fix compatibility with Linux 6.14

### DIFF
--- a/kernel/generic_raw_uart.c
+++ b/kernel/generic_raw_uart.c
@@ -943,10 +943,10 @@ static spinlock_t active_devices_lock;
 static bool active_devices[MAX_DEVICES] = {false};
 
 #if defined(CONFIG_OF) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0))
-static int __match_i2c_client_by_address(struct device *dev, void *addrp)
+static int __match_i2c_client_by_address(struct device *dev, const void *addrp)
 {
   struct i2c_client *client = i2c_verify_client(dev);
-  int addr = *(int *)addrp;
+  int addr = *(const int *)addrp;
   return (client && client->addr == addr) ? 1 : 0;
 }
 


### PR DESCRIPTION
In 6.14, the definition of device_find_child was changed to
`struct device *device_find_child(struct device *parent, const void *data, device_match_t match);`

Where device_match_t is now
`typedef int (*device_match_t)(struct device *dev, const void *data);`