### PR TITLE
hb_rf_eth: use dev_err_ratelimited to prevent kernel log flooding

### DIFF
--- a/kernel/hb_rf_eth.c
+++ b/kernel/hb_rf_eth.c
@@ -134,7 +134,7 @@ static void hb_rf_eth_queue_msg(char cmd, char *buffer, size_t len)
   }
   else
   {
-    dev_err(dev, "No free send buffers\n");
+    dev_err_ratelimited(dev, "No free send buffers\n");
   }
 
   spin_unlock(&queue_write_lock);
@@ -158,18 +158,18 @@ static int hb_rf_eth_recv_packet(struct socket *sock, char *buffer, size_t buffe
   {
     if (len < 4)
     {
-      dev_err(dev, "Received to small UDP packet\n");
+      dev_err_ratelimited(dev, "Received to small UDP packet\n");
       return -EPROTO;
     }
     if (*((uint16_t *)(buffer + len - 2)) != (uint16_t)(htons(hb_rf_eth_calc_crc(buffer, len - 2))))
     {
-      dev_err(dev, "Received UDP packet with invalid checksum\n");
+      dev_err_ratelimited(dev, "Received UDP packet with invalid checksum\n");
       return -EPROTO;
     }
   }
   else if (len != 0 && len != -EAGAIN)
   {
-    dev_err(dev, "Error %d on receiving packet\n", len);
+    dev_err_ratelimited(dev, "Error %d on receiving packet\n", len);
   }
 
   return len;
@@ -228,7 +228,7 @@ static void hb_rf_eth_send_msg(struct socket *sock, char *buffer, size_t len)
   }
   else
   {
-    dev_err(dev, "Error sending packet, not connected\n");
+    dev_err_ratelimited(dev, "Error sending packet, not connected\n");
   }
 }
 


### PR DESCRIPTION
## Problem

When the HB-RF-ETH device becomes unreachable (e.g., network outage), the send thread continues attempting to transmit packets while the receive thread enters a reconnection loop. Each failed send attempt logs "Error sending packet, not connected" with no rate limiting.

### Observed behavior in production:
- Thousands of kernel messages per second
- journald reports "Missed 3020 kernel messages"
- System becomes unresponsive
- VM requires hard restart

## Solution

This patch applies `dev_err_ratelimited()` to all error messages that could potentially be triggered in rapid succession:

| Line | Message | Trigger |
|------|---------|---------|
| 137 | "No free send buffers" | Queue overflow |
| 161 | "Received to small UDP packet" | Malformed packets |
| 166 | "Received UDP packet with invalid checksum" | Corruption |
| 172 | "Error %d on receiving packet" | Receive failures |
| 231 | "Error sending packet, not connected" | Disconnection (critical) |

The kernel's default rate limiting (typically 10 messages per 5 seconds) prevents log flooding while still providing diagnostic information.

## Tested on
- Proxmox VE 9.0.10 (Kernel 6.14.11-3-pve)
- debmatic 3.83.6-121
- pivccu-modules-dkms 1.0.85