### PR TITLE
Update start-hook.sh ->fix /bin/ Pfade

### DIFF
--- a/pivccu/container3/start-hook.sh
+++ b/pivccu/container3/start-hook.sh
@@ -2,18 +2,18 @@
 
 . /var/pivccu/conf
 
-find /var/* -maxdepth 0 ! -name pivccu -exec rm -rf {} \;
-rm -rf /tmp/*
+/bin/find /var/* -maxdepth 0 ! -name pivccu -exec  /bin/rm -rf {} \;
+/bin/rm -rf /tmp/*
 
-rm -f /dev/eq3loop
-rm -f /dev/mmd_bidcos
-rm -f /dev/mmd_hmip
-rm -f /dev/raw-uart
+/bin/rm -f /dev/eq3loop
+/bin/rm -f /dev/mmd_bidcos
+/bin/rm -f /dev/mmd_hmip
+/bin/rm -f /dev/raw-uart
 
-mknod -m 666 /dev/eq3loop c $HM_EQ3LOOP_MAJOR 0
-mknod -m 666 /dev/mmd_hmip c $HM_HMIP_MAJOR $HM_HMIP_MINOR
-mknod -m 666 /dev/mmd_bidcos c $HM_EQ3LOOP_MAJOR 2
-mknod -m 666 /dev/raw-uart c $HM_RAW_UART_MAJOR $HM_RAW_UART_MINOR
+/bin/mknod -m 666 /dev/eq3loop c $HM_EQ3LOOP_MAJOR 0
+/bin/mknod -m 666 /dev/mmd_hmip c $HM_HMIP_MAJOR $HM_HMIP_MINOR
+/bin/mknod -m 666 /dev/mmd_bidcos c $HM_EQ3LOOP_MAJOR 2
+/bin/mknod -m 666 /dev/raw-uart c $HM_RAW_UART_MAJOR $HM_RAW_UART_MINOR
 
 mkdir -p /dev/net
 if [ ! -e /dev/net/tun ]; then


### PR DESCRIPTION
Der LXC-Container startet zwar, aber das start-hook.sh im Container findet grundlegende Binaries nicht (rm, mknod fehlen im PATH). Das passiert nur beim Service-Start, nicht manuell.

Bad: /etc/piVCCU3/start-hook.sh: line 6: rm: not found
Bad: /etc/piVCCU3/start-hook.sh: line 13: mknod: not found

Das start-hook.sh läuft im Container-Kontext ohne vollständigen $PATH (BusyBox/minimaler Initramfs-ähnlicher Modus).

systemd vs. manuell: Service startet LXC mit anderem Environment/Privileges

PATH-Unterschied: Manueller root-Aufruf hat vollen /bin:/usr/bin, systemd-LXC hat minimalen oder leeren PATH

Warum das passiert

Good (manuell):  PATH=/bin:/usr/bin verfügbar → rm/find/mknod funktionieren
Bad (systemd):   PATH leer/minimal → "not found"

LXC-Hooks laufen extrem früh - vor vollständigem Init/Mount des /bin. Manueller Start als root hat normales Shell-Environment, systemd-LXC nicht.

Container-Init: Hook läuft in Phase wo /bin noch nicht gemountet/bind-mounted ist!

siehe bug -> piVCCU and debian trixie: service not working 
https://github.com/alexreinert/piVCCU/issues/556   --->fixed