### PR TITLE
Update pivccu.service ->Fix Service zu früh (Netzwerk) /systemd PIDFile Warnung

### DIFF
--- a/pivccu/host3/pivccu.service
+++ b/pivccu/host3/pivccu.service
@@ -1,14 +1,17 @@
 [Unit]
 Description=piVCCU
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
+Environment=PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin
 ExecStart=/var/lib/piVCCU3/start_container.sh
 ExecStop=/var/lib/piVCCU3/stop_container.sh
 Type=forking
-PIDFile=/var/run/pivccu3.pid
+PIDFile=/run/pivccu3.pid
 TimeoutSec=300s
+Restart=always
+RestartSec=10s
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
Service zu früh -> Netzwerk nicht verfügbar.

Environment=PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin
After=network-online.target
Wants=network-online.target

 kosmetischer Fix systemd-Warnung

PIDFile=/var/run/pivccu3.pid → /run/pivccu3.pid