### PR TITLE
update eq3_char_loop to v1.3

### DIFF
--- a/kernel/eq3_char_loop.c
+++ b/kernel/eq3_char_loop.c
@@ -365,7 +365,7 @@ static ssize_t eq3loop_write_master(struct eq3loop_channel_data* channel, struct
 	{
 		ret=-EFAULT;
 		count_to_end = CIRC_SPACE( head, channel->master2slave_buf.tail, BUFSIZE);
-		printk( KERN_ERR EQ3LOOP_DRIVER_NAME ": eq3loop_write_master() %s: not enought space in the buffers. free space = %zu, required space = %zu", channel->name,count_to_end,count );
+		printk( KERN_ERR EQ3LOOP_DRIVER_NAME ": eq3loop_write_master() %s: not enough space in buffers. free space = %zu, required space = %zu", channel->name,count_to_end,count );
 		goto out;
 	}
 	/* ok, space is free, write something */
@@ -401,7 +401,7 @@ out:
 	up (&channel->sem);
 	if(ret < 0)
 	{
-		printk( KERN_INFO EQ3LOOP_DRIVER_NAME ": eq3loop_write_master() retrun error:");
+		printk( KERN_INFO EQ3LOOP_DRIVER_NAME ": eq3loop_write_master() return error: %zd", ret);
 	}
 	if( ret > 0 || CIRC_CNT(channel->master2slave_buf.head,channel->master2slave_buf.tail,BUFSIZE) )
 	{
@@ -1003,3 +1003,4 @@ module_init(eq3loop_init);
 module_exit(eq3loop_exit);
 MODULE_DESCRIPTION("eQ-3 IPC loopback char driver");
 MODULE_LICENSE("GPL");
+MODULE_VERSION("1.2");

--- a/kernel/eq3_char_loop.c
+++ b/kernel/eq3_char_loop.c
@@ -960,7 +960,14 @@ static int __init eq3loop_init(void)
 		printk(KERN_ERR EQ3LOOP_DRIVER_NAME ": Unable to add driver\n");
 		goto out_unregister_chrdev_region;
 	}
+/* Linux changed signature of class_create in 6.4+
+ * see: https://lore.kernel.org/all/20230324100132.1633647-1-gregkh@linuxfoundation.org/
+*/
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	control_data->class=class_create(THIS_MODULE, EQ3LOOP_DRIVER_NAME);
+#else
+	control_data->class=class_create(EQ3LOOP_DRIVER_NAME);
+#endif
 	if(IS_ERR(control_data->class)){
 		ret = -EIO;
 		printk(KERN_ERR EQ3LOOP_DRIVER_NAME ": Unable to register driver class\n");

--- a/kernel/eq3_char_loop.c
+++ b/kernel/eq3_char_loop.c
@@ -71,10 +71,6 @@
   #define _access_ok(__type, __addr, __size) access_ok(__type, __addr, __size)
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0))
-  #define class_create(__owner, __class) class_create(__class)
-#endif
-
 struct eq3loop_channel_data
 {
 	struct circ_buf master2slave_buf;


### PR DESCRIPTION
This PR updates the sources of eq3_char_loop to the patchset used in OpenCCU which in version 1.3 of eq3_char_loop introduces termios2 compatibility required for glibc 2.42+ systems so that HMIPServer is able to start up when connecting to `/dev/mmd_hmip`.

This refs https://github.com/OpenCCU/OpenCCU/pull/3441