### PR TITLE
eq3_char_loop: return -EAGAIN, not -EFAULT, on full-buffer write

### DIFF
--- a/kernel/eq3_char_loop.c
+++ b/kernel/eq3_char_loop.c
@@ -61,7 +61,7 @@
 #define CONNECTION_TYPE_MASTER 0
 #define CONNECTION_TYPE_SLAVE 1
 
-#define BUFSIZE 1024  //just use buffer size power of 2. otherwise the size and index calculation dosn't work
+#define BUFSIZE 1024  //just use buffer size power of 2. otherwise the size and index calculation doesn't work
 
 #define DUMP_READWRITE 0
 
@@ -404,7 +404,7 @@ out:
 	}
 	if( ret > 0 || CIRC_CNT(channel->master2slave_buf.head,channel->master2slave_buf.tail,BUFSIZE) )
 	{
-		//send a signal to reading procces if return is ok or data in the buffer
+		//send a signal to reading process if return is ok or data in the buffer
 		wake_up_interruptible( &channel->master2slaveq );
 	}
 	

--- a/kernel/eq3_char_loop.c
+++ b/kernel/eq3_char_loop.c
@@ -289,7 +289,8 @@ static ssize_t eq3loop_write_slave(struct eq3loop_channel_data* channel, struct 
 	head = channel->slave2master_buf.head;
 	if(CIRC_SPACE( head, channel->slave2master_buf.tail, BUFSIZE) < count)
 	{
-		ret=-EFAULT;
+		/* no room for a whole frame yet -- let the writer retry */
+		ret=-EAGAIN;
 		goto out;
 	}
 	
@@ -360,9 +361,10 @@ static ssize_t eq3loop_write_master(struct eq3loop_channel_data* channel, struct
 	head = channel->master2slave_buf.head;
 	if(CIRC_SPACE( head, channel->master2slave_buf.tail, BUFSIZE) < count)
 	{
-		ret=-EFAULT;
+		/* no room for a whole frame yet -- let the writer retry */
+		ret=-EAGAIN;
 		count_to_end = CIRC_SPACE( head, channel->master2slave_buf.tail, BUFSIZE);
-		printk( KERN_ERR EQ3LOOP_DRIVER_NAME ": eq3loop_write_master() %s: not enough space in buffers. free space = %zu, required space = %zu", channel->name,count_to_end,count );
+		printk_ratelimited( KERN_ERR EQ3LOOP_DRIVER_NAME ": eq3loop_write_master() %s: not enough space in buffers. free space = %zu, required space = %zu", channel->name,count_to_end,count );
 		goto out;
 	}
 	/* ok, space is free, write something */
@@ -1071,4 +1073,4 @@ module_init(eq3loop_init);
 module_exit(eq3loop_exit);
 MODULE_DESCRIPTION("eQ-3 IPC loopback char driver");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("1.3");
+MODULE_VERSION("1.4");


### PR DESCRIPTION
Fixes #591.

`eq3loop_write_slave()` and `eq3loop_write_master()` returned `-EFAULT` when the loopback ring buffer could not currently hold a whole frame (`CIRC_SPACE < count`). `-EFAULT` means "bad userspace address", but the address is fine — this is ordinary, transient backpressure. `HMIPServer` reaches the slave device through `librxtx`, which maps `EFAULT` to a fatal `java.io.IOException` ("Ungültige Adresse"), so it treats a recoverable full buffer as unrecoverable and stops writing. The HmIP stack then stays dead until a reboot while BidCos-RF keeps working.

**Change:** return `-EAGAIN` (retryable) at the two backpressure sites, leaving the legitimate `copy_from_user()` EFAULTs untouched. The master-side `KERN_ERR` log line is changed to `printk_ratelimited` because, under the retryable errno, the writer retries and an unthrottled message would flood the kernel log.

This is the minimal, latency-neutral part of the fix. Full backpressure (block until a whole frame fits) is intentionally left out — `multimacd` runs under `SCHED_FIFO`, so a blocking write needs separate latency review.

A second commit fixes two unrelated comment typos in the same file (`dosn't` → `doesn't`, `procces` → `process`).

### Confirmed
- On **debmatic** (which ships this module via `pivccu-modules-dkms`, kernel 6.12.90, HmIP over HB-RF-ETH): captured the full field signature — repeated `java.io.IOException: Ungültige Adresse in writeArray`, `eq3loop_write_master() … not enough space in buffers`, orphaned `/dev/mmd_hmip`, BidCos still up.
- Isolated userspace reproduction against the unmodified module (no RF hardware): a blocking slave write of a frame larger than the remaining free space returns `errno 14 (EFAULT)` instead of blocking/`EAGAIN`.

### Related
- OpenCCU/OpenCCU#3968 — root-cause analysis + reproduction
- OpenCCU/OpenCCU#3969 — the same errno fix on OpenCCU's copy of this driver
- alexreinert/debmatic#426 / alexreinert/debmatic#427 — the orchestration half (a lone `multimacd` restart orphaning the slaves)


---

### Testing wanted (hardware)

I don't have a piVCCU/debmatic box with a radio to confirm this live. If you can:

1. Build `pivccu-modules-dkms` with this change and load it.
2. With `HMIPServer` running, induce the loopback-full condition — e.g. a lone `systemctl restart debmatic-multimacd` (see alexreinert/debmatic#427) that orphans `/dev/mmd_hmip`.
3. Confirm the fatal `java.io.IOException: Ungültige Adresse in writeArray` no longer appears (full buffer → `EAGAIN`, not the fatal `EFAULT`).

Results welcome.
